### PR TITLE
切换视图监听增加返回切换前的视图状态。

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ multipleStatusView.showContent();
 //设置重试视图点击事件
 multipleStatusView.setOnRetryClickListener(onRetryClickListener);
 
+//设置视图状态切换监听事件
+mMultipleStatusView.setOnViewStatusChangeListener(OnViewStatusChangeListener);
+
 /**
 * 获取当前view的状态
 *      MultipleStatusView.STATUS_LOADING   //当前为加载中视图

--- a/app/src/main/java/com/classic/common/simple/AbsActivity.java
+++ b/app/src/main/java/com/classic/common/simple/AbsActivity.java
@@ -68,9 +68,11 @@ public abstract class AbsActivity extends AppCompatActivity implements View.OnCl
 
     final MultipleStatusView.OnViewStatusChangeListener mViewStatusChangeListener = new MultipleStatusView.OnViewStatusChangeListener() {
         @Override
-        public void onChange(int viewStatus) {
-            Log.d("MultipleStatusView", "viewStatus=" + viewStatus);
+        public void onChange(int formerViewStatus, int newViewStatus) {
+            Log.d("MultipleStatusView", "formerViewStatus=" +
+                    formerViewStatus + ",newViewStatus=" + newViewStatus);
         }
+
     };
 
     @Override public void onClick(View v) {

--- a/multiple-status-view/src/main/java/com/classic/common/MultipleStatusView.java
+++ b/multiple-status-view/src/main/java/com/classic/common/MultipleStatusView.java
@@ -342,7 +342,11 @@ public class MultipleStatusView extends RelativeLayout {
      * 视图状态改变接口
      */
     public interface OnViewStatusChangeListener {
-        void onChange(int viewStatus);
+        /**
+         * @param formerViewStatus 切换前的视图状态
+         * @param newViewStatus    切换后的视图状态
+         */
+        void onChange(int formerViewStatus, int newViewStatus);
     }
 
     /**
@@ -360,9 +364,10 @@ public class MultipleStatusView extends RelativeLayout {
      * @param viewStatus 当前的视图状态
      */
     private void changeViewStatus(int viewStatus) {
-        mViewStatus = viewStatus;
         if (null != mViewStatusListener) {
-            mViewStatusListener.onChange(mViewStatus);
+            mViewStatusListener.onChange(mViewStatus, viewStatus);
         }
+        mViewStatus = viewStatus;
+
     }
 }


### PR DESCRIPTION
1. 为了更完善，切换视图时应该同时返回切换前和切换后的状态；
2. 在Readme中添加视图状态切换监听事件的说明。
